### PR TITLE
Image thumbnails not visible in List view in IE8

### DIFF
--- a/sass/list.scss
+++ b/sass/list.scss
@@ -146,6 +146,7 @@ ul.r-list{
     }
     .listing-thumb{
         float:left;
+        width:95px;
     }
     .listing-thumb img{
         height: 85px;


### PR DESCRIPTION
IE8 has a drawing issue when outside wrapper does not have a defined width and the inner img tag is fixed, resulting in image with 0 size (invisible)
