### PR TITLE
Fixed PHP 7.1 Illegal string offset 'pk_i_id'

### DIFF
--- a/search-sidebar.php
+++ b/search-sidebar.php
@@ -18,7 +18,7 @@
      *      You should have received a copy of the GNU Affero General Public
      * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
      */
-     $category = __get("category");
+     $category = (array)__get("category");
      if(!isset($category['pk_i_id']) ) {
          $category['pk_i_id'] = null;
      }


### PR DESCRIPTION
Hi!, I fixed error Warning: Illegal string offset 'pk_i_id' in /home/forge/domain.com/public/oc-content/themes/osclasswizards/search-sidebar.php on line 23

In PHP 7.1 we need cast the data to array. Testing in PHP 7.1.1 and PHP 7.1.8